### PR TITLE
Feature/duplicate playtask prevention

### DIFF
--- a/interfaces/StatementParser.cpp
+++ b/interfaces/StatementParser.cpp
@@ -50,7 +50,7 @@ namespace DosboxStagingReplacer {
         return *this;
     }
 
-    std::any PlayTaskLaunchParameters::fillFromStatement(const std::any stmt, const std::vector<std::string> parameters,
+    std::any PlayTaskLaunchParameter::fillFromStatement(const std::any stmt, const std::vector<std::string> parameters,
                                                          const SqlEngine engine) {
         const auto parser = StatementParserFactory::createParser(engine);
         parser->parseInto(*this, parameters, stmt);
@@ -152,7 +152,7 @@ namespace DosboxStagingReplacer {
         }
     }
 
-    void SqliteStatementParser::parseInto(PlayTaskLaunchParameters &result, std::vector<std::string> parameters,
+    void SqliteStatementParser::parseInto(PlayTaskLaunchParameter &result, std::vector<std::string> parameters,
                                           const std::any stmtAny) {
         auto *stmt = std::any_cast<sqlite3_stmt *>(stmtAny);
         for (int i = 0; i < sqlite3_column_count(stmt); ++i) {

--- a/interfaces/StatementParser.h
+++ b/interfaces/StatementParser.h
@@ -231,7 +231,7 @@ namespace DosboxStagingReplacer {
     /**
      * @brief PlayTaskLaunchParameters class. Contains the information about a play task launch parameters.
      */
-    class PlayTaskLaunchParameters final : public SqlDataResult {
+    class PlayTaskLaunchParameter final : public SqlDataResult {
         using SqlDataResult::SqlDataResult;
 
     public:
@@ -239,6 +239,11 @@ namespace DosboxStagingReplacer {
         std::string executablePath;
         std::string commandLineArgs;
         std::string label;
+
+        bool operator==(const PlayTaskLaunchParameter &other) const {
+            return executablePath == other.executablePath &&
+                   commandLineArgs == other.commandLineArgs;
+        }
 
         /**
          * @brief Fills the PlayTaskLaunchParameters object with data from the statement.
@@ -345,7 +350,7 @@ namespace DosboxStagingReplacer {
          * @param parameters The parameters to use.
          * @param stmt The statement to parse.
          */
-        virtual void parseInto(PlayTaskLaunchParameters &result, std::vector<std::string> parameters,
+        virtual void parseInto(PlayTaskLaunchParameter &result, std::vector<std::string> parameters,
                                std::any stmt) = 0;
         /**
          * @brief Parses a SQL result into a PlayTaskLaunchParameters object.
@@ -381,7 +386,7 @@ namespace DosboxStagingReplacer {
         void parseInto(PlayTaskInformation &result, std::vector<std::string> parameters, std::any stmtAny) override;
         //! \copydoc DosboxStagingReplacer::StatementParser::parseInto(DosboxStagingReplacer::PlayTaskLaunchParameters&,
         //! std::vector<std::string>, std::any)
-        void parseInto(PlayTaskLaunchParameters &result, std::vector<std::string> parameters,
+        void parseInto(PlayTaskLaunchParameter &result, std::vector<std::string> parameters,
                        std::any stmtAny) override;
         //! \copydoc DosboxStagingReplacer::StatementParser::parseInto(DosboxStagingReplacer::PlayTaskType&,
         //! std::vector<std::string>, std::any)

--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
     // Initialize the file backup service
 
     // Parse command line arguments using argparse
-    argparse::ArgumentParser program("Dosbox Staging Replacer", "1.0.2");
+    argparse::ArgumentParser program("Dosbox Staging Replacer", "1.0.3");
     program.add_argument("-f", "--file")
             .help("The Galaxy database file")
             .default_value(std::string("galaxy-2.0.db"))

--- a/services/gog/GogGalaxyService.cpp
+++ b/services/gog/GogGalaxyService.cpp
@@ -87,16 +87,16 @@ namespace DosboxStagingReplacer {
     }
 
     void GogGalaxyService::insertPlayTaskLaunchParameter(const PlayTaskInformation &playTask,
-                                                          const PlayTaskLaunchParameter &launchParameters) {
+                                                          const PlayTaskLaunchParameter &launchParameter) {
         if (this->validDatabase) {
             this->sqlService.executeQuery(R"SQL(
                 INSERT INTO PlayTaskLaunchParameters (playTaskId, executablePath, commandLineArgs, label)
                 VALUES (:playTaskId, :executablePath, :commandLineArgs, :label);
             )SQL",
                                           {{"playTaskId", playTask.id},
-                                           {"executablePath", launchParameters.executablePath},
-                                           {"commandLineArgs", launchParameters.commandLineArgs},
-                                           {"label", launchParameters.label}});
+                                           {"executablePath", launchParameter.executablePath},
+                                           {"commandLineArgs", launchParameter.commandLineArgs},
+                                           {"label", launchParameter.label}});
         } else {
             throw GogGalaxyServiceException("Database connection is not open");
         }

--- a/services/gog/GogGalaxyService.cpp
+++ b/services/gog/GogGalaxyService.cpp
@@ -86,8 +86,8 @@ namespace DosboxStagingReplacer {
         throw GogGalaxyServiceException("Database connection is not open");
     }
 
-    void GogGalaxyService::insertPlayTaskLaunchParameters(const PlayTaskInformation &playTask,
-                                                          const PlayTaskLaunchParameters &launchParameters) {
+    void GogGalaxyService::insertPlayTaskLaunchParameter(const PlayTaskInformation &playTask,
+                                                          const PlayTaskLaunchParameter &launchParameters) {
         if (this->validDatabase) {
             this->sqlService.executeQuery(R"SQL(
                 INSERT INTO PlayTaskLaunchParameters (playTaskId, executablePath, commandLineArgs, label)
@@ -148,8 +148,7 @@ namespace DosboxStagingReplacer {
             if (releaseKey.has_value()) {
                 query += " WHERE ptr.releaseKey = :releaseKey;";
                 params.insert({"releaseKey", releaseKey.value()});
-            }
-            else {
+            } else {
                 query += ";";
             }
 
@@ -164,9 +163,9 @@ namespace DosboxStagingReplacer {
                 for (const auto &product: result) {
                     try {
                         if (auto filesInPath = DirectoryScanner::scanDirectory(product.installationPath);
-                        std::ranges::any_of(filesInPath, [](const auto &file) {
-                            return file.path.find("DOSBOX") != std::string::npos;
-                        })) {
+                            std::ranges::any_of(filesInPath, [](const auto &file) {
+                                return file.path.find("DOSBOX") != std::string::npos;
+                            })) {
                             filteredResult.push_back(product);
                         }
                     } catch (const std::exception &e) {
@@ -187,7 +186,8 @@ namespace DosboxStagingReplacer {
                 SELECT
                     id
                 FROM Users;
-            )SQL", {});
+            )SQL",
+                                                                 {});
             return result;
         }
         throw GogGalaxyServiceException("Database connection is not open");
@@ -234,28 +234,28 @@ namespace DosboxStagingReplacer {
         throw GogGalaxyServiceException("Database connection is not open");
     }
 
-    std::vector<PlayTaskLaunchParameters> GogGalaxyService::getPlayTaskLaunchParameters() {
+    std::vector<PlayTaskLaunchParameter> GogGalaxyService::getPlayTaskLaunchParameters() {
         if (this->validDatabase) {
-            auto result = this->sqlService.executeQuery<PlayTaskLaunchParameters>(R"SQL(
+            auto result = this->sqlService.executeQuery<PlayTaskLaunchParameter>(R"SQL(
                 SELECT
                     ptlp.playTaskId, ptlp.executablePath, ptlp.commandLineArgs, ptlp.label
                 FROM PlayTaskLaunchParameters ptlp
             )SQL",
-                                                                                  {});
+                                                                                 {});
             return result;
         }
         throw GogGalaxyServiceException("Database connection is not open");
     }
 
-    std::vector<PlayTaskLaunchParameters> GogGalaxyService::getPlayTaskLaunchParametersFromPlayTaskId(int playTaskId) {
+    std::vector<PlayTaskLaunchParameter> GogGalaxyService::getPlayTaskLaunchParametersFromPlayTaskId(int playTaskId) {
         if (this->validDatabase) {
-            auto result = this->sqlService.executeQuery<PlayTaskLaunchParameters>(R"SQL(
+            auto result = this->sqlService.executeQuery<PlayTaskLaunchParameter>(R"SQL(
                 SELECT
                     ptlp.playTaskId, ptlp.executablePath, ptlp.commandLineArgs, ptlp.label
                 FROM PlayTaskLaunchParameters ptlp
                 WHERE ptlp.playTaskId = :playTaskId;
             )SQL",
-                                                                                  {{"playTaskId", playTaskId}});
+                                                                                 {{"playTaskId", playTaskId}});
             return result;
         }
         throw GogGalaxyServiceException("Database connection is not open");
@@ -263,28 +263,50 @@ namespace DosboxStagingReplacer {
 
     void GogGalaxyService::addPlayTask(const int64_t userId, const std::string &gameReleaseKey,
                                        const PlayTaskInformation &playTask,
-                                       const PlayTaskLaunchParameters &launchParameters) {
+                                       const PlayTaskLaunchParameter &launchParameter) {
         if (this->validDatabase) {
             // Get all PlayTasks under the given gameReleaseKey
             auto existingPlayTasks = this->getPlayTasksFromGameReleaseKey(gameReleaseKey);
-            int max_order = -1;
+            int maxOrder = -1;
+
+            // Get all PlayTasks that have custom type
+            std::vector<int> customPlayTaskId;
 
             // Get the maximum order of the existing PlayTasks
             for (const auto &task: existingPlayTasks) {
-                if (task.order > max_order)
-                    max_order = task.order;
+                if (task.order > maxOrder)
+                    maxOrder = task.order;
+                if (task.type == "Custom")
+                    customPlayTaskId.push_back(task.id);
+            }
+
+            // Before we begin, we first check if there is need to create a new PlayTask
+            // To do this, we check if there are any existing PlayTasks having the same
+            // launch parameters as the one we are trying to add and if so we skip the insertion
+
+            for (const auto &playTaskId: customPlayTaskId) {
+                for (auto customLaunchParametersForCustomPlayTask =
+                             this->getPlayTaskLaunchParametersFromPlayTaskId(playTaskId);
+                     const auto &customLaunchParameter: customLaunchParametersForCustomPlayTask) {
+                    if (customLaunchParameter == launchParameter) {
+                        // If we find a PlayTask with the same launch parameters, we skip the insertion
+                        std::cerr << "PlayTask with the same launch parameters already exists. Skipping insertion."
+                                  << std::endl;
+                        return;
+                    }
+                }
             }
 
             // If there are no existing PlayTasks, set max_order to 1
             // This will only become -1 if there are no PlayTasks at all
-            max_order = max_order == -1 ? 1 : max_order + 1;
+            maxOrder = maxOrder == -1 ? 1 : maxOrder + 1;
 
             // Set all existing PlayTasks to not primary
             this->disableAllPlayTaskFor(gameReleaseKey);
             // Add the new PlayTask, get the updated PlayTask
-            const auto updatedPlayTask = this->insertPlayTask(userId, max_order, playTask);
+            const auto updatedPlayTask = this->insertPlayTask(userId, maxOrder, playTask);
             // Add the PlayTaskLaunchParameters
-            this->insertPlayTaskLaunchParameters(updatedPlayTask, launchParameters);
+            this->insertPlayTaskLaunchParameter(updatedPlayTask, launchParameter);
             return;
         }
         throw GogGalaxyServiceException("Database connection is not open");
@@ -296,7 +318,8 @@ namespace DosboxStagingReplacer {
                 UPDATE ProductSettings
                 SET customLaunchParameters = :enabled
                 WHERE gameReleaseKey = :releaseKey;
-            )SQL", {{"enabled", enabled}, {"releaseKey", gameReleaseKey}});
+            )SQL",
+                                          {{"enabled", enabled}, {"releaseKey", gameReleaseKey}});
             return;
         }
         throw GogGalaxyServiceException("Database connection is not open");

--- a/services/gog/GogGalaxyService.h
+++ b/services/gog/GogGalaxyService.h
@@ -24,7 +24,7 @@ namespace DosboxStagingReplacer {
 
         void disableAllPlayTaskFor(const std::string& gameReleaseKey);
         PlayTaskInformation insertPlayTask(int64_t userId, int new_order, const PlayTaskInformation &playTask);
-        void insertPlayTaskLaunchParameters(const PlayTaskInformation &playTask, const PlayTaskLaunchParameters &launchParameters);
+        void insertPlayTaskLaunchParameter(const PlayTaskInformation &playTask, const PlayTaskLaunchParameter &launchParameters);
 
     public:
         /**
@@ -102,14 +102,14 @@ namespace DosboxStagingReplacer {
          * @brief Retrieves all play task launch parameters from the database.
          * @return A vector of PlayTaskLaunchParameters objects.
          */
-        std::vector<PlayTaskLaunchParameters> getPlayTaskLaunchParameters();
+        std::vector<PlayTaskLaunchParameter> getPlayTaskLaunchParameters();
 
         /**
          * @brief Retrieves launch parameters associated with a specific play task ID.
          * @param playTaskId The ID of the play task.
          * @return A vector of PlayTaskLaunchParameters objects.
          */
-        std::vector<PlayTaskLaunchParameters> getPlayTaskLaunchParametersFromPlayTaskId(int playTaskId);
+        std::vector<PlayTaskLaunchParameter> getPlayTaskLaunchParametersFromPlayTaskId(int playTaskId);
 
         /**
          * @brief Inserts a new play task and its associated launch parameters to the database.
@@ -117,10 +117,10 @@ namespace DosboxStagingReplacer {
          * @param userId ID of the user to assign the task to.
          * @param gameReleaseKey Release key of the game.
          * @param playTask The play task information.
-         * @param launchParameters The associated launch parameters.
+         * @param launchParameter The associated launch parameters.
          */
         void addPlayTask(int64_t userId, const std::string &gameReleaseKey, const PlayTaskInformation &playTask,
-                         const PlayTaskLaunchParameters &launchParameters);
+                         const PlayTaskLaunchParameter &launchParameter);
 
         /**
          * @brief Sets custom launch parameters for a specific product in the database.

--- a/services/gog/GogGalaxyService.h
+++ b/services/gog/GogGalaxyService.h
@@ -24,7 +24,7 @@ namespace DosboxStagingReplacer {
 
         void disableAllPlayTaskFor(const std::string& gameReleaseKey);
         PlayTaskInformation insertPlayTask(int64_t userId, int new_order, const PlayTaskInformation &playTask);
-        void insertPlayTaskLaunchParameter(const PlayTaskInformation &playTask, const PlayTaskLaunchParameter &launchParameters);
+        void insertPlayTaskLaunchParameter(const PlayTaskInformation &playTask, const PlayTaskLaunchParameter &launchParameter);
 
     public:
         /**


### PR DESCRIPTION
This PR adds a checks when adding play tasks so that users will not end up having multiple duplicate entries in their custom executable if in such an event that they use -rd again on a game that has already been processed