### PR TITLE
Feature/controlled dosbox config files

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -119,6 +119,21 @@ int main(int argc, char *argv[]) {
             .help("The name of the output file. If \"\", the output will be printed to the console.")
             .default_value(std::string(""))
             .nargs(1);
+    program.add_argument("-cfsdf", "--change-fullscreen-default")
+            .help("Replaces the predefined value of the fullscreen value in the Dosbox config file to the Dosbox's defaults")
+            .default_value(std::string("yes"))
+            .choices("yes", "no", "true", "false")
+            .nargs(1);
+    program.add_argument("-crsdf", "--change-resolution-default")
+            .help("Replaces the predefined value of the resolutions(fullresolution, windowresolution) value in the Dosbox config file to the Dosbox's defaults")
+            .default_value(std::string("yes"))
+            .choices("yes", "no", "true", "false")
+            .nargs(1);
+    program.add_argument("-cmpdf", "--change-mapping-default")
+            .help("Removes the mapping value in the Dosbox config file")
+            .default_value(std::string("yes"))
+            .choices("yes", "no", "true", "false")
+            .nargs(1);
 
     try {
         program.parse_args(argc, argv);
@@ -127,6 +142,15 @@ int main(int argc, char *argv[]) {
         std::cerr << program;
         return 1;
     }
+
+    auto is_enabled = [&](const char* option) {
+        const auto value = program.get<std::string>(option);
+        return value != "no" && value != "false";
+    };
+
+    const bool replaceFullscreenDefaults = is_enabled("--change-fullscreen-default");
+    const bool replaceResolutionDefaults = is_enabled("--change-resolution-default");
+    const bool removeMappingDefaults     = is_enabled("--change-mapping-default");
 
     // Let us add flags checking where flags such as backup, restore, list-applications, list-games, list-backups
     //  and replace-dosbox cannot be used together. We declare a vector of bools to check, with the set of flags
@@ -472,7 +496,18 @@ int main(int argc, char *argv[]) {
             for (const auto &dosboxConfig: dosboxConfigFiles) {
                 std::filesystem::path dosboxConfigPath = dosboxConfig.path;
                 std::cout << "Modifying " << dosboxConfig.path << "..." << std::endl;
-                DosboxStagingReplacer::ScriptEditService::disableFullScreenForDosboxConfig(dosboxConfigPath);
+                if (replaceFullscreenDefaults) {
+                    std::cout << "Replacing fullscreen=true with fullscreen=false" << std::endl;
+                    DosboxStagingReplacer::ScriptEditService::disableFullScreenForDosboxConfig(dosboxConfigPath);
+                }
+                if (replaceResolutionDefaults) {
+                    std::cout << "Replacing resolution values for fullscreen and windowed display modes to defaults" << std::endl;
+                    DosboxStagingReplacer::ScriptEditService::replaceDisplayToDefaultForDosboxConfig(dosboxConfigPath);
+                }
+                if (removeMappingDefaults) {
+                    std::cout << "Removing overwritten mapping values and resetting it to defaults" << std::endl;
+                    DosboxStagingReplacer::ScriptEditService::disableOverwrittenMappingForDosboxConfig(dosboxConfigPath);
+                }
             }
             std::cout << "Successfully modified config files" << std::endl;
             std::cout << "Modifications complete! You may need to restart Gog galaxy to see the changes" << std::endl;

--- a/services/ScriptEditService.cpp
+++ b/services/ScriptEditService.cpp
@@ -111,7 +111,8 @@ namespace DosboxStagingReplacer {
         std::filesystem::remove(tmpFilePath);
     }
 
-    void ScriptEditService::disableFullScreenForDosboxConfig(std::filesystem::path &filePath, const std::string &tmpExtension) {
+    void ScriptEditService::disableFullScreenForDosboxConfig(std::filesystem::path &filePath,
+                                                             const std::string &tmpExtension) {
         // We open two files, the original file and a tmp file
         std::fstream file(filePath);
         std::filesystem::path tmpFilePath = filePath;
@@ -153,4 +154,102 @@ namespace DosboxStagingReplacer {
         // We also remove the tmp file
         std::filesystem::remove(tmpFilePath);
     }
+    void ScriptEditService::disableOverwrittenMappingForDosboxConfig(std::filesystem::path &filePath,
+                                                                     const std::string &tmpExtension) {
+        // We open two files, the original file and a tmp file
+        std::fstream file(filePath);
+        std::filesystem::path tmpFilePath = filePath;
+        tmpFilePath += tmpExtension;
+
+        // Double check first if the tmp file exists, if so we do something like .tmp2, tmp3, etc
+        if (fileExists(tmpFilePath.string())) {
+            int counter = 2;
+            while (fileExists(tmpFilePath.string())) {
+                tmpFilePath = filePath;
+                tmpFilePath += tmpExtension + std::to_string(counter);
+                counter++;
+            }
+        }
+        std::fstream tmpFile(tmpFilePath, std::ios::out);
+
+        // We slowly stream the file line by line and replace each line with any modifications
+        if (file.is_open() && tmpFile.is_open()) {
+            std::string line;
+            while (std::getline(file, line)) {
+                // Check if the line contains a path
+                auto lowerLine = line;
+                std::ranges::transform(lowerLine, lowerLine.begin(), tolower);
+                if (lowerLine.find("mapperfile=") == std::string::npos) {
+                    tmpFile << line << std::endl;
+                }
+            }
+        }
+
+        // Close the files
+        file.close();
+        tmpFile.close();
+        // Remove the original file
+        std::filesystem::remove(filePath);
+        // Rename the tmp file to the original file
+        std::filesystem::rename(tmpFilePath, filePath);
+        // We also remove the tmp file
+        std::filesystem::remove(tmpFilePath);
+    }
+    void ScriptEditService::replaceDisplayToDefaultForDosboxConfig(std::filesystem::path &filePath,
+                                                                   const std::string &tmpExtension) {
+        // We open two files, the original file and a tmp file
+        std::fstream file(filePath);
+        std::filesystem::path tmpFilePath = filePath;
+        tmpFilePath += tmpExtension;
+
+        // Double check first if the tmp file exists, if so we do something like .tmp2, tmp3, etc
+        if (fileExists(tmpFilePath.string())) {
+            int counter = 2;
+            while (fileExists(tmpFilePath.string())) {
+                tmpFilePath = filePath;
+                tmpFilePath += tmpExtension + std::to_string(counter);
+                counter++;
+            }
+        }
+        std::fstream tmpFile(tmpFilePath, std::ios::out);
+
+        // We slowly stream the file line by line and replace each line with any modifications
+        if (file.is_open() && tmpFile.is_open()) {
+            std::string line;
+            while (std::getline(file, line)) {
+                // Check if the line contains a path
+                auto lowerLine = line;
+                std::ranges::transform(lowerLine, lowerLine.begin(), tolower);
+                if (lowerLine.find("fullresolution=") != std::string::npos) {
+                    // Find the value of fullresolution and if the value is not desktop we replace it
+                    // what is the default
+                    if (auto fullResolutionValue = line.substr(line.find('=') + 1); fullResolutionValue != "desktop") {
+                        replaceAll(line, fullResolutionValue, "desktop");
+                    }
+                }
+                else if (lowerLine.find("windowresolution=") != std::string::npos) {
+                    // Find the value of windowresolution and if the value is not desktop we replace it
+                    // what is the default
+                    if (auto windowResolutionValue = line.substr(line.find('=') + 1);
+                        windowResolutionValue != "original") {
+                        replaceAll(line, windowResolutionValue, "original");
+                    }
+                }
+                // Write the modified line to the tmp file
+                tmpFile << line << std::endl;
+            }
+        }
+
+        // Close the files
+        file.close();
+        tmpFile.close();
+        // Remove the original file
+        std::filesystem::remove(filePath);
+        // Rename the tmp file to the original file
+        std::filesystem::rename(tmpFilePath, filePath);
+        // We also remove the tmp file
+        std::filesystem::remove(tmpFilePath);
+    }
+
+
 } // DosboxStagingReplacer

--- a/services/ScriptEditService.h
+++ b/services/ScriptEditService.h
@@ -50,6 +50,21 @@ namespace DosboxStagingReplacer {
          * @param tmpExtension The extension to use for the temporary file
          */
         static void disableFullScreenForDosboxConfig(std::filesystem::path &filePath, const std::string &tmpExtension = ".tmp");
+
+        /**
+         * @brief Disables the mapping config for the DOSBox configuration file some games have.
+         * @param filePath
+         * @param tmpExtension
+         */
+        static void disableOverwrittenMappingForDosboxConfig(std::filesystem::path &filePath, const std::string &tmpExtension = ".tmp");
+
+        /**
+         * @brief Replaces the fullscreenresolution and windowresolution to the default's values
+         * which is desktop and original respectively
+         * @param filePath
+         * @param tmpExtension
+         */
+        static void replaceDisplayToDefaultForDosboxConfig(std::filesystem::path &filePath, const std::string &tmpExtension = ".tmp");
     };
 
 } // DosboxStagingReplacer


### PR DESCRIPTION
This PR introduces new flags to the program, these are -cfsdf (--change-fullscreen-default), -crsdf (--change-resolution-default) and -cmpdf (--change-mapping-default)

Originally -cfsdf is always applied but now can be turned off if needed, -crsdf and -cmpdf are new features meant to override resolution and mapping settings to Dosbox's default values