### PR TITLE
Merge changes from main to develop (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A utility designed to seamlessly replace the default DOSBox bundled with GOG Gal
 
 ---
 
-## 📚 Full Documentation
+## Full Documentation
 
 Complete details about installation, usage, development, and internal architecture are available on the [**Wiki**](https://github.com/Shin-Aska/DosboxStagingReplacerForGOGGalaxy/wiki).
 
@@ -22,7 +22,7 @@ Complete details about installation, usage, development, and internal architectu
 
 ---
 
-## ⚡ Quick Start
+## Quick Start
 
 Download the latest binary from [Releases](https://github.com/Shin-Aska/DosboxStagingReplacerForGOGGalaxy/releases):
 
@@ -34,7 +34,7 @@ See [How to Use](https://github.com/Shin-Aska/DosboxStagingReplacerForGOGGalaxy/
 
 ------
 
-## 🚩 Requirements
+## Requirements
 
 - Windows 10 or later (Recommended)
 - GOG Galaxy client installed
@@ -42,12 +42,12 @@ See [How to Use](https://github.com/Shin-Aska/DosboxStagingReplacerForGOGGalaxy/
 
 ------
 
-## 🤝 Contributions
+## Contributions
 
 Contributions, improvements, and suggestions are welcome! Visit the [Contributing Guide](https://github.com/Shin-Aska/DosboxStagingReplacerForGOGGalaxy/wiki/Contributing-to-Development) for details.
 
 ------
 
-## 📜 License
+## License
 
 Licensed under the MIT License.

--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
     // Initialize the file backup service
 
     // Parse command line arguments using argparse
-    argparse::ArgumentParser program("Dosbox Staging Replacer", "1.0.4");
+    argparse::ArgumentParser program("Dosbox Staging Replacer", "1.0.6");
     program.add_argument("-f", "--file")
             .help("The Galaxy database file")
             .default_value(std::string("galaxy-2.0.db"))

--- a/services/ScriptEditService.cpp
+++ b/services/ScriptEditService.cpp
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iostream>
+#include <ranges>
 
 namespace DosboxStagingReplacer {
 
@@ -56,13 +58,72 @@ namespace DosboxStagingReplacer {
         return false;
     }
 
+    std::string ScriptEditService::transformConfArg(const std::string &arg, const std::filesystem::path &basePath) {
+        std::size_t lastDot = std::string::npos;
+        bool hasSeparator = false;
+
+        for (std::size_t i = 0; i < arg.size(); ++i) {
+            const char c = arg[i];
+            if (c == '"') { continue; }
+            if (c == '.') { lastDot = i; continue; }
+            break;
+        }
+
+        std::string out = arg;
+        if (lastDot != std::string::npos) {
+            std::string tail = (lastDot + 1 < arg.size()) ? arg.substr(lastDot + 1) : std::string{};
+            std::string tail2 = (lastDot + 1 < arg.size()) ? arg.substr(lastDot + 1) : std::string{};
+
+            if (tail.back() == '"') {
+                tail = tail.substr(0, tail.size() - 1);
+            }
+
+            if (basePath.string().back() == '\\' && tail.front() == '\\') {
+                tail = tail.substr(1);
+                hasSeparator = true;
+            }
+            else if (basePath.string().back() == '\\' || tail.front() == '\\') {
+                hasSeparator = true;
+            }
+            out = basePath.string() + (hasSeparator ? "" : "\\") + tail;
+        } else {
+            if (basePath.string().back() == '\\' || out.front() == '\\') {
+                hasSeparator = true;
+            }
+            else if (basePath.string().back() == '\\' && out.front() == '\\') {
+                out = out.substr(1);
+                hasSeparator = true;
+            }
+            out = basePath.string() + (hasSeparator ? "" : "\\") + out;
+        }
+
+        if (out.empty() || out.front() != '"')
+            out = "\"" + out + "\"";
+
+        return out;
+    }
+
     std::string ScriptEditService::resolveRelativePathsFromString(const std::string &cmd,
                                                                   const std::filesystem::path &basePath) {
-        // Copy cmd to a new variable
-        std::string result = cmd;
-        // Replace all relative paths with absolute paths
-        replaceAll(result, "..", basePath.string());
-        return result;
+        std::istringstream in(cmd);
+        std::ostringstream out;
+        std::string token;
+        bool first = true;
+
+        while (in >> token) {
+            if (!first) out << ' ';
+            first = false;
+
+            if (token == "-conf") {
+                out << token;
+                if (std::string param; in >> param) {
+                    out << ' ' << transformConfArg(param, basePath);
+                }
+            } else {
+                out << token;
+            }
+        }
+        return out.str();
     }
 
     void ScriptEditService::resolveRelativePathsForDosboxAutoExec(std::filesystem::path &filePath,
@@ -93,7 +154,11 @@ namespace DosboxStagingReplacer {
                 std::ranges::transform(lowerLine, lowerLine.begin(), tolower);
                 // Check if the line contains the strings "imgmount" or "mount" (case-insensitive)
                 if (lowerLine.find("mount") != std::string::npos || lowerLine.find("imgmount") != std::string::npos) {
+                    line = sanitizeDosboxMountPath(line);
+                    // Replace all back relative path to absolute path
                     replaceAll(line, "..", basePath.string());
+                    // Replace all current relative path to absolute path
+                    replaceAll(line, ".", basePath.string());
                 }
                 // Write the modified line to the tmp file
                 tmpFile << line << std::endl;
@@ -230,6 +295,7 @@ namespace DosboxStagingReplacer {
                 else if (lowerLine.find("windowresolution=") != std::string::npos) {
                     // Find the value of windowresolution and if the value is not desktop we replace it
                     // what is the default
+                    std::cerr << "windowresolution -> " << line << " " << filePath << std::endl;
                     if (auto windowResolutionValue = line.substr(line.find('=') + 1);
                         windowResolutionValue != "original") {
                         replaceAll(line, windowResolutionValue, "original");
@@ -249,6 +315,58 @@ namespace DosboxStagingReplacer {
         std::filesystem::rename(tmpFilePath, filePath);
         // We also remove the tmp file
         std::filesystem::remove(tmpFilePath);
+    }
+
+std::string ScriptEditService::sanitizeDosboxMountPath(const std::string &params) {
+        // Replicates the Python logic provided, keeping behavior consistent.
+        std::string targetDrive;
+        std::string targetPath;
+
+        const auto pos = params.find("mount");
+        if (pos == std::string::npos) {
+            // If "mount" isn't found, return the input unchanged (conservative fallback).
+            return params;
+        }
+
+        const std::string mountParams = params.substr(pos + 5); // characters after "mount"
+
+        bool startParsing = false;
+        std::size_t lastIndex = std::string::npos;
+
+        // Parse targetDrive (the first non-space token after "mount")
+        for (std::size_t idx = 0; idx < mountParams.size(); ++idx) {
+            const char c = mountParams[idx];
+
+            if (c != ' ') startParsing = true;
+
+            if (startParsing) {
+                if (c == ' ') {
+                    lastIndex = idx;
+                    break;
+                } else {
+                    targetDrive.push_back(c);
+                }
+            }
+        }
+
+        // Parse targetPath (the rest after the first separating space)
+        if (lastIndex != std::string::npos) {
+            const std::string pathParams = (lastIndex + 1 < mountParams.size())
+                                           ? mountParams.substr(lastIndex + 1)
+                                           : std::string{};
+
+            startParsing = false;
+            for (const char c : pathParams) {
+                if (c != ' ') startParsing = true;
+                if (startParsing) targetPath.push_back(c);
+            }
+
+            if (!targetPath.empty() && targetPath.front() != '"') {
+                targetPath = "\"" + targetPath + "\"";
+            }
+        }
+
+        return "mount " + targetDrive + " " + targetPath;
     }
 
 

--- a/services/ScriptEditService.h
+++ b/services/ScriptEditService.h
@@ -65,6 +65,26 @@ namespace DosboxStagingReplacer {
          * @param tmpExtension
          */
         static void replaceDisplayToDefaultForDosboxConfig(std::filesystem::path &filePath, const std::string &tmpExtension = ".tmp");
+
+
+        /**
+         *
+         * @param arg The current argument from Gog Galaxy
+         * @param basePath The basePath string that we can use to replace relative path strings
+         * @return A transformed config argument that has its relative path's replace with absolute path strings
+         */
+        static std::string transformConfArg(const std::string& arg, const std::filesystem::path &basePath);
+
+        /**
+         * @brief Sanitizes the given DOSBox mount path.
+         *
+         * This function processes the provided path to ensure it meets the
+         * requirements or conventions expected for DOSBox mount paths.
+         *
+         * @param path The DOSBox mount path to be sanitized.
+         * @return A sanitized version of the given mount path.
+         */
+        static std::string sanitizeDosboxMountPath(const std::string &path);
     };
 
 } // DosboxStagingReplacer

--- a/services/gog/GogGalaxyService.cpp
+++ b/services/gog/GogGalaxyService.cpp
@@ -285,7 +285,7 @@ namespace DosboxStagingReplacer {
                                        const PlayTaskLaunchParameter &launchParameter) {
         if (this->validDatabase) {
             // Get all PlayTasks under the given gameReleaseKey
-            auto existingPlayTasks = this->getPlayTasksFromGameReleaseKey(gameReleaseKey);
+            const auto existingPlayTasks = this->getPlayTasksFromGameReleaseKey(gameReleaseKey);
             int maxOrder = -1;
 
             // Get all PlayTasks that have custom type

--- a/tests/TestScriptEditService.cpp
+++ b/tests/TestScriptEditService.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include "ScriptEditService.h"
+
+int main() {
+    // Test case 1: Savage Empire paths
+    const struct {
+        std::string cmd = R"(-conf "..\dosboxSAVAGE.conf" -conf "..\dosboxSAVAGE_single.conf" -noconsole -c "exit")";
+        std::filesystem::path path = R"(C:\Program Files (x86)\GOG Galaxy\Games\The Savage Empire\)";
+        std::string expected =
+                R"(-conf "C:\Program Files (x86)\GOG Galaxy\Games\The Savage Empire\dosboxSAVAGE.conf" -conf "C:\Program Files (x86)\GOG Galaxy\Games\The Savage Empire\dosboxSAVAGE_single.conf" -noconsole -c "exit")";
+    } test1;
+
+    // Test case 2: War of the Lance paths
+    const struct {
+        std::string cmd = "-noconsole -conf ..\\flame-base.conf -conf flame-graphics.conf -conf flame-game.conf";
+        std::filesystem::path path = R"(C:\Program Files (x86)\GOG Galaxy\Games\War of the Lance)";
+        std::string expected =
+                R"(-noconsole -conf "C:\Program Files (x86)\GOG Galaxy\Games\War of the Lance\flame-base.conf" -conf "C:\Program Files (x86)\GOG Galaxy\Games\War of the Lance\flame-graphics.conf" -conf "C:\Program Files (x86)\GOG Galaxy\Games\War of the Lance\flame-game.conf")";
+    } test2;
+
+    const std::string result1 =
+            DosboxStagingReplacer::ScriptEditService::resolveRelativePathsFromString(test1.cmd, test1.path);
+    const std::string result2 =
+            DosboxStagingReplacer::ScriptEditService::resolveRelativePathsFromString(test2.cmd, test2.path);
+
+    bool failed = false;
+
+    if (result1 != test1.expected) {
+        std::cerr << "Test case 1 failed:" << std::endl;
+        std::cerr << "Expected: " << test1.expected << std::endl;
+        std::cerr << "Got: " << result1 << std::endl;
+        failed = true;
+    }
+
+    if (result2 != test2.expected) {
+        std::cerr << "Test case 2 failed:" << std::endl;
+        std::cerr << "Expected: " << test2.expected << std::endl;
+        std::cerr << "Got: " << result2 << std::endl;
+        failed = true;
+    }
+
+    return failed ? 1 : 0;
+}


### PR DESCRIPTION
* Update README.md

Remove emojis in the Readme

* Update path handling utilities and add tests (#15)

* Add utility methods for DOSBox config transformation and path sanitization

* Add `transformConfArg` and `sanitizeDosboxMountPath` methods for path transformations and resolve relative paths in DOSBox config handling

* Add a basic test for `ScriptEditService` to verify relative path resolution

* Refactor `existingPlayTasks` declaration to use `const auto` for improved clarity

* Bump the application version to 1.0.5

* Bump the application version to 1.0.6

* Fixes bug #14